### PR TITLE
Only upload addons from Linux; also ignore a few mac specific files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.DS_Store
+buildbot/config.sh

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -53,7 +53,7 @@ if [ doUpdate ] || [ $force == "-f" ]; then
 	# Get the current hash	
 	curhash=`git rev-parse HEAD`
 
-	if [ buildNgale lasthash ]; then
+	if [ buildNgale ]; then
 		makePackage $version $branchname $buildnumber
 		uploadPackages
 	else

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -1,12 +1,12 @@
-# !/bin/bash
+#!/bin/bash
 
 set -e
 
-#  Include the config file
+# Include the config file
 source config.sh
 export PATH=$PATH
 
-#  Check the OS
+# Check the OS
 case $OSTYPE in
 	linux*)   osname='linux' ;;
 	msys*)    osname='windows' ;;
@@ -16,62 +16,65 @@ case $OSTYPE in
 	*)        osname='unknown' ;;
 esac
 
-if [ "$osname" == "macosx" ]; then
-	arch="i686"
-else
-	#  Check the architecture platform (eg. i686)
-	arch=`uname -m`
-fi
+# Check the architecture
+[ "$osname" == "macosx" ] && { arch="i686" } || { arch=`uname -m` }
 
-#  Today date
+# Today's date
 ngalebuild=`date "+%Y-%m-%d"`
 
-#  One day before to get git changes
-if [ "$osname" == "macosx" ]; then
-	daybefore=`date -v -1d "+%Y-%m-%d"`
-else
-	daybefore=`date "+%Y-%m-%d" --date '1 days ago'`
-fi
+# One day before to get git changes
+[ "$osname" == "macosx" ] && { daybefore=`date -v -1d "+%Y-%m-%d"` } || { daybefore=`date "+%Y-%m-%d" --date '1 days ago'` }
 
-#  Going to the repo folder
+# Going to the repo folder
 cd "${repo}"
 
-#  Clean up
+# Clean up
 git reset --hard
 
-#  Checkout the right branch
+# Checkout the right branch
 git checkout ${branch}
 
-#  Fetch changes from GitHub
+# Get the hash for the last built version
+[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
+
+# Fetch changes from GitHub
 git fetch origin
-#  Merge
 
-ngalechange=`git merge origin/${branch}`
+# Rebase on the origin
+git rebase origin/${branch}
 
-#  If there are new changes or using -f parameter,
-#  let's build !
-if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
-	#  Get the buildnumber
+# Get the hash for the latest commit
+curhash=`git rev-parse HEAD`
+
+# If the hash is different, it's time to build new!
+if [ "$curhash" != "$lasthash" ]; then
+	# Get the buildnumber
 	buildnumber=`cat build/sbBuildInfo.mk.in | grep BuildNumber= | sed -e 's/BuildNumber=//g'`
-	#  Get the version
+	
+	# Get the version
 	version=`cat build/sbBuildInfo.mk.in | grep SB_MILESTONE= | sed 's/SB_MILESTONE=//g'`
-	#  Get the branchname
+	
+	# Get the branchname
 	branchname=`cat build/sbBuildInfo.mk.in | grep SB_BRANCHNAME= | sed 's/SB_BRANCHNAME=//g'`
 
-	#  Check if we are on trunk
-	if [ "$branchname" != 'sb-trunk-oldxul' ]; then
-		branchname=`echo $branchname | sed 's/Songbird//g'`
-	fi
+	# Check if we are on trunk
+	[ "$branchname" != 'sb-trunk-oldxul' ] && { branchname=`echo $branchname | sed 's/Songbird//g'` }
 
-	#  remove old build
-	make clobber
+	# Remove the old build
+	make clean
 
+	# Build!!!
 	cd ${repo}
-	bash ./build.sh |tee "${repo}/buildlog"
+	bash ./build.sh | tee "$repo/buildlog"
 
-	if [ "`cat buildlog|grep 'Succeeded'`" ]; then
+	# If everything worked...
+	if [ "`grep Succeeded buildlog`" ]; then
+		# Store the currently built hash as the last since it succeeded
+		echo $curhash > "$compiled/lastbuilt.txt"
+
 		mv compiled/dist compiled/Nightingale
 		cd compiled
+
 		changes=`git log --after={${daybefore}}`
 		echo "Nightingale "$version" - branch "$branchname" - build "$buildnumber > README.md
 		echo "" >> README.md
@@ -80,7 +83,7 @@ if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
 		echo "Changes:" >> README.md
 		echo "" >> README.md
 
-		if [ "$changes" = "" ]; then
+		if [ "$changes" == "" ]; then
 			echo "none" >> README.md
 			cat /dev/null > changes.txt
 		else
@@ -91,51 +94,48 @@ if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
 		if [ "$osname" == "windows" ]; then
 			# Zip
 			zip -r -9 nightingale-${version}-${buildnumber}_${osname}-${arch}.zip Nightingale
+			
 			# Making a md5sum
 			md5sum nightingale-${version}-${buildnumber}_${osname}-${arch}.zip > nightingale-${version}-${buildnumber}_${osname}-${arch}.zip.md5
-		else
-			if [ "$osname" != "macosx" ]; then
-				# Tar then bz2
-				tar cvf nightingale-${version}-${buildnumber}_${osname}-${arch}.tar Nightingale
-				bzip2 nightingale-${version}-${buildnumber}_${osname}-${arch}.tar
+		fi
+		
+		if [ "$osname" == "linux" ]; then
+			# Tar then bz2
+			tar cvf nightingale-${version}-${buildnumber}_${osname}-${arch}.tar Nightingale
+			bzip2 nightingale-${version}-${buildnumber}_${osname}-${arch}.tar
 
-				# Making a md5 sum
-				md5sum nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2 > nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2.md5
-			fi
+			# Making a md5 sum
+			md5sum nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2 > nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2.md5
 		fi
 
 		# Creating a folder and moving the file to be reachable
 		mkdir $compiled/$ngalebuild
-		[ "$osname" == "linux" ] && mkdir $compiled/$ngalebuild/addons
+		mkdir $compiled/$ngalebuild/addons
+
 		[ "$osname" != "macosx" ] && mv nightingale-${version}-${buildnumber}_${osname}-${arch}.* $compiled/$ngalebuild
 		mv changes.txt $compiled/$ngalebuild
 		mv README.md $compiled/$ngalebuild
 
 		# Unless we have binary addons, we should always use the Linux built ones
-		if [ "$osname" = "linux" ]; then
-			mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
-			mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
-			mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
-			mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
-			mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
-		fi
+		mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
+		mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
+		mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
+		mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
+		mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
 
-		if [ "$osname" == "windows" ] || [ "$osname" = "macosx" ]; then
-			mv _built_installer/* $compiled/$ngalebuild
-		fi
+		[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
 
-		if [ $(test -d $compiled/latest) ]; then
-			rm -rf $compiled/latest
-		fi
+		# Remove the old local "latest" directory
+		[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
 		
-		mkdir $compiled/latest
+		# Copy everything over to "latest" ...rsync because Macs are weird
 		rsync -aPr $compiled/$ngalebuild/* $compiled/latest
 
 		# Uploading on sourceforge.net
-		cd "${compiled}"
+		cd $compiled
 		rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
 		rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-		[ -d "$compiled/latest/addons" ] && rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+		rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
 	else
 		echo "Build failed! See buildlog for details"
 	fi

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -106,7 +106,7 @@ if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
 
 		# Creating a folder and moving the file to be reachable
 		mkdir $compiled/$ngalebuild
-		mkdir $compiled/$ngalebuild/addons
+		[ "$osname" == "linux" ] && mkdir $compiled/$ngalebuild/addons
 		[ "$osname" != "macosx" ] && mv nightingale-${version}-${buildnumber}_${osname}-${arch}.* $compiled/$ngalebuild
 		mv changes.txt $compiled/$ngalebuild
 		mv README.md $compiled/$ngalebuild
@@ -135,7 +135,7 @@ if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
 		cd "${compiled}"
 		rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
 		rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-		rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+		[ -d "$compiled/latest/addons" ] && rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
 	else
 		echo "Build failed! See buildlog for details"
 	fi

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -1,4 +1,4 @@
--#!/bin/bash
+#!/bin/bash
 
 set -e
 
@@ -25,6 +25,9 @@ ngalebuild=`date "+%Y-%m-%d"`
 # One day before to get git changes
 [ "$osname" == "macosx" ] && daybefore=`date -v -1d "+%Y-%m-%d"` || daybefore=`date "+%Y-%m-%d" --date '1 days ago'`
 
+# Get our functions
+source functions.sh
+
 # Update, and build if we have changes
 if [ doUpdate ]; then
 	cd $repo
@@ -45,117 +48,5 @@ if [ doUpdate ]; then
 else
 	echo "No changes since last time, exiting."
 fi
-
-function doUpdate() {
-	cd $repo
-
-	# Clean up
-	git reset --hard
-
-	# Checkout the right branch
-	git checkout $branch
-
-	# Fetch changes from GitHub
-	git fetch origin
-
-	# Rebase on the origin
-	git rebase origin/$branch
-
-	# Get the hash for the last built version
-	[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
-	
-	# Get the current hash	
-	lasthash=`git rev-parse HEAD`	
-	
-	# Return true if we need to rebuild
-	[ "$curhash" != "$lasthash" ] && return 0 || return 1
-}
-
-function buildNgale() {
-	cd $repo
-
-	# Remove the old build
-	make clean
-
-	# Build!!!
-	bash ./build.sh | tee "$repo/buildlog"
-
-	# If everything worked...
-	[ "`grep Succeeded buildlog`" ] && return 0 || return 1
-}
-
-function makePackage() {
-	# Store the currently built hash as the last since it succeeded
-	echo $curhash > "$compiled/lastbuilt.txt"
-
-	mv compiled/dist compiled/Nightingale
-	cd compiled
-
-	changes=`git log --after={${daybefore}}`
-	echo "Nightingale "$1" - branch "$2" - build "$3 > README.md
-	echo "" >> README.md
-	echo "Git source: <https://github.com/nightingale-media-player/nightingale-hacking/tree/"$branch">" >> README.md
-	echo "" >> README.md
-	echo "Changes:" >> README.md
-	echo "" >> README.md
-
-	if [ "$changes" == "" ]; then
-		echo "none" >> README.md
-		cat /dev/null > changes.txt
-	else
-		echo "$changes" >> README.md
-		echo "$changes" > changes.txt
-	fi
-
-	if [ "$osname" == "windows" ]; then
-		# Zip
-		zip -r -9 nightingale-$1-$3_$osname-$arch.zip Nightingale
-		
-		# Making a md5sum
-		md5sum nightingale-$1-$3_$osname-$arch.zip > nightingale-$1-$3_$osname-$arch.zip.md5
-	fi
-	
-	if [ "$osname" == "linux" ]; then
-		# Tar then bz2
-		tar cvf nightingale-$1-$3_$osname-$arch.tar Nightingale
-		bzip2 nightingale-$1-$3_$osname-$arch.tar
-
-		# Making a md5 sum
-		md5sum nightingale-$1-$3_$osname-$arch.tar.bz2 > nightingale-$1-$3_$osname-$arch.tar.bz2.md5
-	fi
-
-	# Creating a folder and moving the file to be reachable
-	mkdir $compiled/$ngalebuild
-	mkdir $compiled/$ngalebuild/addons
-
-	[ "$osname" != "macosx" ] && mv nightingale-$1-$3_$osname-$arch.* $compiled/$ngalebuild
-	mv changes.txt $compiled/$ngalebuild
-	mv README.md $compiled/$ngalebuild
-
-	# Unless we have binary addons, we should always use the Linux built ones
-	mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
-	mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
-	mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
-	mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
-	mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
-
-	[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
-
-	# Remove the old local "latest" directory
-	[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
-	
-	# Copy everything over to "latest" ...rsync because Macs are weird
-	rsync -aPr $compiled/$ngalebuild/* $compiled/latest
-	
-	uploadPackages
-}
-
-function uploadPackages() {
-	# Uploading on sourceforge.net
-	cd $compiled
-	rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-	rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-	rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
-}
 
 exit 0

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -124,13 +124,12 @@ if [ "$ngalechange" != 'Already up-to-date.' ] || [ "$1" = "-f" ]; then
 			mv _built_installer/* $compiled/$ngalebuild
 		fi
 
-		if test -d $compiled/latest; then
-			echo ""
-		else
-			mkdir $compiled/latest
+		if [ $(test -d $compiled/latest) ]; then
+			rm -rf $compiled/latest
 		fi
-
-		cp $compiled/$ngalebuild/* $compiled/latest -r
+		
+		mkdir $compiled/latest
+		rsync -aPr $compiled/$ngalebuild/* $compiled/latest
 
 		# Uploading on sourceforge.net
 		cd "${compiled}"

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -44,9 +44,7 @@ if [ doUpdate ]; then
 	# Check if we are on trunk
 	[ "$branchname" != 'sb-trunk-oldxul' ] && branchname=`echo $branchname | sed 's/Songbird//g'`
 
-	buildNgale && makePackage $version $branchname $buildnumber && uploadPackages || echo "We encountered a build error."
+	buildNgale && makePackage $version $branchname $buildnumber && uploadPackages && echo "Buildbot success!" && exit 0 || echo "We encountered a build error." exit 1
 else
 	echo "No changes since last time, exiting."
 fi
-
-exit 0

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -16,6 +16,9 @@ case $OSTYPE in
 	*)        osname='unknown' ;;
 esac
 
+# Make sure the ssh keys are setup
+ssh-add
+
 # Check the architecture
 [ "$osname" == "macosx" ] && arch="i686" || arch=`uname -m`
 

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -49,9 +49,6 @@ if [ doUpdate ] || [ $force == "-f" ]; then
 
 	# Check if we are on trunk
 	[ "$branchname" != 'sb-trunk-oldxul' ] && branchname=`echo $branchname | sed 's/Songbird//g'`
-	
-	# Get the current hash	
-	curhash=`git rev-parse HEAD`
 
 	if [ buildNgale ]; then
 		makePackage $version $branchname $buildnumber

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -25,29 +25,10 @@ ngalebuild=`date "+%Y-%m-%d"`
 # One day before to get git changes
 [ "$osname" == "macosx" ] && { daybefore=`date -v -1d "+%Y-%m-%d"` } || { daybefore=`date "+%Y-%m-%d" --date '1 days ago'` }
 
-# Going to the repo folder
-cd "${repo}"
+# Update, and build if we have changes
+if [ doUpdate ]; then
+	cd $repo
 
-# Clean up
-git reset --hard
-
-# Checkout the right branch
-git checkout ${branch}
-
-# Get the hash for the last built version
-[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
-
-# Fetch changes from GitHub
-git fetch origin
-
-# Rebase on the origin
-git rebase origin/${branch}
-
-# Get the hash for the latest commit
-curhash=`git rev-parse HEAD`
-
-# If the hash is different, it's time to build new!
-if [ "$curhash" != "$lasthash" ]; then
 	# Get the buildnumber
 	buildnumber=`cat build/sbBuildInfo.mk.in | grep BuildNumber= | sed -e 's/BuildNumber=//g'`
 	
@@ -60,85 +41,121 @@ if [ "$curhash" != "$lasthash" ]; then
 	# Check if we are on trunk
 	[ "$branchname" != 'sb-trunk-oldxul' ] && { branchname=`echo $branchname | sed 's/Songbird//g'` }
 
+	[ buildNgale ] && [ makePackage($version, $branchname, $buildnumber) ] && uploadPackages || echo "We encountered a build error."
+else
+	echo "No changes since last time, exiting."
+fi
+
+function doUpdate() {
+	cd $repo
+
+	# Clean up
+	git reset --hard
+
+	# Checkout the right branch
+	git checkout $branch
+
+	# Fetch changes from GitHub
+	git fetch origin
+
+	# Rebase on the origin
+	git rebase origin/$branch
+
+	# Get the hash for the last built version
+	[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
+	
+	# Get the current hash	
+	lasthash=`git rev-parse HEAD`	
+	
+	# Return true if we need to rebuild
+	[ "$curhash" != "$lasthash" ] && return 0 || return 1
+}
+
+function buildNgale() {
+	cd $repo
+
 	# Remove the old build
 	make clean
 
 	# Build!!!
-	cd ${repo}
 	bash ./build.sh | tee "$repo/buildlog"
 
 	# If everything worked...
-	if [ "`grep Succeeded buildlog`" ]; then
-		# Store the currently built hash as the last since it succeeded
-		echo $curhash > "$compiled/lastbuilt.txt"
+	[ "`grep Succeeded buildlog`" ] && return 0 || return 1
+}
 
-		mv compiled/dist compiled/Nightingale
-		cd compiled
+function makePackage() {
+	# Store the currently built hash as the last since it succeeded
+	echo $curhash > "$compiled/lastbuilt.txt"
 
-		changes=`git log --after={${daybefore}}`
-		echo "Nightingale "$version" - branch "$branchname" - build "$buildnumber > README.md
-		echo "" >> README.md
-		echo "Git source: <https://github.com/nightingale-media-player/nightingale-hacking/tree/"$branch">" >> README.md
-		echo "" >> README.md
-		echo "Changes:" >> README.md
-		echo "" >> README.md
+	mv compiled/dist compiled/Nightingale
+	cd compiled
 
-		if [ "$changes" == "" ]; then
-			echo "none" >> README.md
-			cat /dev/null > changes.txt
-		else
-			echo "$changes" >> README.md
-			echo "$changes" > changes.txt
-		fi
+	changes=`git log --after={${daybefore}}`
+	echo "Nightingale "$1" - branch "$2" - build "$3 > README.md
+	echo "" >> README.md
+	echo "Git source: <https://github.com/nightingale-media-player/nightingale-hacking/tree/"$branch">" >> README.md
+	echo "" >> README.md
+	echo "Changes:" >> README.md
+	echo "" >> README.md
 
-		if [ "$osname" == "windows" ]; then
-			# Zip
-			zip -r -9 nightingale-${version}-${buildnumber}_${osname}-${arch}.zip Nightingale
-			
-			# Making a md5sum
-			md5sum nightingale-${version}-${buildnumber}_${osname}-${arch}.zip > nightingale-${version}-${buildnumber}_${osname}-${arch}.zip.md5
-		fi
-		
-		if [ "$osname" == "linux" ]; then
-			# Tar then bz2
-			tar cvf nightingale-${version}-${buildnumber}_${osname}-${arch}.tar Nightingale
-			bzip2 nightingale-${version}-${buildnumber}_${osname}-${arch}.tar
-
-			# Making a md5 sum
-			md5sum nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2 > nightingale-${version}-${buildnumber}_${osname}-${arch}.tar.bz2.md5
-		fi
-
-		# Creating a folder and moving the file to be reachable
-		mkdir $compiled/$ngalebuild
-		mkdir $compiled/$ngalebuild/addons
-
-		[ "$osname" != "macosx" ] && mv nightingale-${version}-${buildnumber}_${osname}-${arch}.* $compiled/$ngalebuild
-		mv changes.txt $compiled/$ngalebuild
-		mv README.md $compiled/$ngalebuild
-
-		# Unless we have binary addons, we should always use the Linux built ones
-		mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
-		mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
-		mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
-		mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
-		mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
-
-		[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
-
-		# Remove the old local "latest" directory
-		[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
-		
-		# Copy everything over to "latest" ...rsync because Macs are weird
-		rsync -aPr $compiled/$ngalebuild/* $compiled/latest
-
-		# Uploading on sourceforge.net
-		cd $compiled
-		rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-		rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
-		rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+	if [ "$changes" == "" ]; then
+		echo "none" >> README.md
+		cat /dev/null > changes.txt
 	else
-		echo "Build failed! See buildlog for details"
+		echo "$changes" >> README.md
+		echo "$changes" > changes.txt
 	fi
-else
-	echo "Nothing to do, bye !"
-fi
+
+	if [ "$osname" == "windows" ]; then
+		# Zip
+		zip -r -9 nightingale-$1-$3_$osname-$arch.zip Nightingale
+		
+		# Making a md5sum
+		md5sum nightingale-$1-$3_$osname-$arch.zip > nightingale-$1-$3_$osname-$arch.zip.md5
+	fi
+	
+	if [ "$osname" == "linux" ]; then
+		# Tar then bz2
+		tar cvf nightingale-$1-$3_$osname-$arch.tar Nightingale
+		bzip2 nightingale-$1-$3_$osname-$arch.tar
+
+		# Making a md5 sum
+		md5sum nightingale-$1-$3_$osname-$arch.tar.bz2 > nightingale-$1-$3_$osname-$arch.tar.bz2.md5
+	fi
+
+	# Creating a folder and moving the file to be reachable
+	mkdir $compiled/$ngalebuild
+	mkdir $compiled/$ngalebuild/addons
+
+	[ "$osname" != "macosx" ] && mv nightingale-$1-$3_$osname-$arch.* $compiled/$ngalebuild
+	mv changes.txt $compiled/$ngalebuild
+	mv README.md $compiled/$ngalebuild
+
+	# Unless we have binary addons, we should always use the Linux built ones
+	mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
+
+	[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
+
+	# Remove the old local "latest" directory
+	[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
+	
+	# Copy everything over to "latest" ...rsync because Macs are weird
+	rsync -aPr $compiled/$ngalebuild/* $compiled/latest
+	
+	uploadPackages
+}
+
+function uploadPackages() {
+	# Uploading on sourceforge.net
+	cd $compiled
+	rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
+	rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
+	rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+}
+
+exit 0

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -51,7 +51,7 @@ if [ doUpdate ] || [ $force == "-f" ]; then
 	[ "$branchname" != 'sb-trunk-oldxul' ] && branchname=`echo $branchname | sed 's/Songbird//g'`
 
 	# Build, package, and upload if we don't hit any errors
-	[ buildNgale ] && [ makePackage $version $branchname $buildnumber ] && [ uploadPackages ] && echo "Buildbot complete." || echo "Build error." && exit 1
+	buildNgale && makePackage $version $branchname $buildnumber && uploadPackages && echo "Buildbot complete." || echo "Build, packaging, or upload error." && exit 1
 else
 	echo "No changes since last time, exiting."
 	exit 0

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -17,13 +17,13 @@ case $OSTYPE in
 esac
 
 # Check the architecture
-[ "$osname" == "macosx" ] && { arch="i686" } || { arch=`uname -m` }
+[ "$osname" == "macosx" ] && arch="i686" || arch=`uname -m`
 
 # Today's date
 ngalebuild=`date "+%Y-%m-%d"`
 
 # One day before to get git changes
-[ "$osname" == "macosx" ] && { daybefore=`date -v -1d "+%Y-%m-%d"` } || { daybefore=`date "+%Y-%m-%d" --date '1 days ago'` }
+[ "$osname" == "macosx" ] && daybefore=`date -v -1d "+%Y-%m-%d"` || daybefore=`date "+%Y-%m-%d" --date '1 days ago'`
 
 # Update, and build if we have changes
 if [ doUpdate ]; then

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -50,13 +50,8 @@ if [ doUpdate ] || [ $force == "-f" ]; then
 	# Check if we are on trunk
 	[ "$branchname" != 'sb-trunk-oldxul' ] && branchname=`echo $branchname | sed 's/Songbird//g'`
 
-	if [ buildNgale ]; then
-		makePackage $version $branchname $buildnumber
-		uploadPackages
-	else
-		echo "Build error."
-		exit 1
-	fi
+	# Build, package, and upload if we don't hit any errors
+	[ buildNgale ] && [ makePackage $version $branchname $buildnumber ] && [ uploadPackages ] && echo "Buildbot complete." || echo "Build error." && exit 1
 else
 	echo "No changes since last time, exiting."
 	exit 0

--- a/buildbot/buildbot_ng.sh
+++ b/buildbot/buildbot_ng.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+-#!/bin/bash
 
 set -e
 
@@ -39,9 +39,9 @@ if [ doUpdate ]; then
 	branchname=`cat build/sbBuildInfo.mk.in | grep SB_BRANCHNAME= | sed 's/SB_BRANCHNAME=//g'`
 
 	# Check if we are on trunk
-	[ "$branchname" != 'sb-trunk-oldxul' ] && { branchname=`echo $branchname | sed 's/Songbird//g'` }
+	[ "$branchname" != 'sb-trunk-oldxul' ] && branchname=`echo $branchname | sed 's/Songbird//g'`
 
-	[ buildNgale ] && [ makePackage($version, $branchname, $buildnumber) ] && uploadPackages || echo "We encountered a build error."
+	buildNgale && makePackage $version $branchname $buildnumber && uploadPackages || echo "We encountered a build error."
 else
 	echo "No changes since last time, exiting."
 fi

--- a/buildbot/functions.sh
+++ b/buildbot/functions.sh
@@ -16,11 +16,8 @@ function doUpdate() {
 	# Get the hash for the last built version
 	[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
 	
-	# Get the current hash	
-	lasthash=`git rev-parse HEAD`	
-	
 	# Return true if we need to rebuild
-	[ "$curhash" != "$lasthash" ] && return 0 || return 1
+	[ "`git rev-parse HEAD`" != "$lasthash" ] && return 0 || return 1
 }
 
 function buildNgale() {
@@ -33,13 +30,10 @@ function buildNgale() {
 	bash ./build.sh | tee "$repo/buildlog"
 
 	# If everything worked...
-	[ "`grep Succeeded buildlog`" ] && return 0 || return 1
+	[ "`grep Succeeded buildlog`" ] && echo $curhash > "$compiled/lastbuilt.txt" && return 0 || return 1
 }
 
 function makePackage() {
-	# Store the currently built hash as the last since it succeeded
-	echo $curhash > "$compiled/lastbuilt.txt"
-
 	mv compiled/dist compiled/Nightingale
 	cd compiled
 
@@ -108,4 +102,9 @@ function uploadPackages() {
 	rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
 	rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
 	rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+}
+
+function quitWithError() {
+	echo $1
+	exit 1
 }

--- a/buildbot/functions.sh
+++ b/buildbot/functions.sh
@@ -99,7 +99,7 @@ function makePackage() {
 	# Copy everything over to "latest" ...rsync because Macs are weird
 	rsync -aPr $compiled/$ngalebuild/* $compiled/latest
 	
-	uploadPackages
+	return 0
 }
 
 function uploadPackages() {

--- a/buildbot/functions.sh
+++ b/buildbot/functions.sh
@@ -77,8 +77,8 @@ function makePackage() {
 	fi
 
 	# Creating a folder and moving the file to be reachable
-	mkdir $compiled/$ngalebuild
-	mkdir $compiled/$ngalebuild/addons
+	[ -d "$compiled/$ngalebuild/addons" ] && rm -rf "$compiled/$ngalebuild/addons"
+	mkdir -p "$compiled/$ngalebuild/addons"
 
 	[ "$osname" != "macosx" ] && mv nightingale-$1-$3_$osname-$arch.* $compiled/$ngalebuild
 	mv changes.txt $compiled/$ngalebuild
@@ -94,7 +94,7 @@ function makePackage() {
 	[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
 
 	# Remove the old local "latest" directory
-	[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
+	[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*"
 	
 	# Copy everything over to "latest" ...rsync because Macs are weird
 	rsync -aPr $compiled/$ngalebuild/* $compiled/latest

--- a/buildbot/functions.sh
+++ b/buildbot/functions.sh
@@ -1,0 +1,111 @@
+function doUpdate() {
+	cd $repo
+
+	# Clean up
+	git reset --hard
+
+	# Checkout the right branch
+	git checkout $branch
+
+	# Fetch changes from GitHub
+	git fetch origin
+
+	# Rebase on the origin
+	git rebase origin/$branch
+
+	# Get the hash for the last built version
+	[ -f "$compiled/lastbuilt.txt" ] && lasthash=`cat "$compiled/lastbuilt.txt"` || lasthash="new" 
+	
+	# Get the current hash	
+	lasthash=`git rev-parse HEAD`	
+	
+	# Return true if we need to rebuild
+	[ "$curhash" != "$lasthash" ] && return 0 || return 1
+}
+
+function buildNgale() {
+	cd $repo
+
+	# Remove the old build
+	make clean
+
+	# Build!!!
+	bash ./build.sh | tee "$repo/buildlog"
+
+	# If everything worked...
+	[ "`grep Succeeded buildlog`" ] && return 0 || return 1
+}
+
+function makePackage() {
+	# Store the currently built hash as the last since it succeeded
+	echo $curhash > "$compiled/lastbuilt.txt"
+
+	mv compiled/dist compiled/Nightingale
+	cd compiled
+
+	changes=`git log --after={${daybefore}}`
+	echo "Nightingale "$1" - branch "$2" - build "$3 > README.md
+	echo "" >> README.md
+	echo "Git source: <https://github.com/nightingale-media-player/nightingale-hacking/tree/"$branch">" >> README.md
+	echo "" >> README.md
+	echo "Changes:" >> README.md
+	echo "" >> README.md
+
+	if [ "$changes" == "" ]; then
+		echo "none" >> README.md
+		cat /dev/null > changes.txt
+	else
+		echo "$changes" >> README.md
+		echo "$changes" > changes.txt
+	fi
+
+	if [ "$osname" == "windows" ]; then
+		# Zip
+		zip -r -9 nightingale-$1-$3_$osname-$arch.zip Nightingale
+		
+		# Making a md5sum
+		md5sum nightingale-$1-$3_$osname-$arch.zip > nightingale-$1-$3_$osname-$arch.zip.md5
+	fi
+	
+	if [ "$osname" == "linux" ]; then
+		# Tar then bz2
+		tar cvf nightingale-$1-$3_$osname-$arch.tar Nightingale
+		bzip2 nightingale-$1-$3_$osname-$arch.tar
+
+		# Making a md5 sum
+		md5sum nightingale-$1-$3_$osname-$arch.tar.bz2 > nightingale-$1-$3_$osname-$arch.tar.bz2.md5
+	fi
+
+	# Creating a folder and moving the file to be reachable
+	mkdir $compiled/$ngalebuild
+	mkdir $compiled/$ngalebuild/addons
+
+	[ "$osname" != "macosx" ] && mv nightingale-$1-$3_$osname-$arch.* $compiled/$ngalebuild
+	mv changes.txt $compiled/$ngalebuild
+	mv README.md $compiled/$ngalebuild
+
+	# Unless we have binary addons, we should always use the Linux built ones
+	mv xpi-stage/albumartlastfm/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/audioscrobbler/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/concerts/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/mashTape/*.xpi $compiled/$ngalebuild/addons
+	mv xpi-stage/shoutcast-radio/*.xpi $compiled/$ngalebuild/addons
+
+	[ -d _built_installer ] && mv _built_installer/* $compiled/$ngalebuild
+
+	# Remove the old local "latest" directory
+	[ -d "$compiled/latest" ] && rm -rf "$compiled/latest/*" || mkdir "$compiled/latest"
+	
+	# Copy everything over to "latest" ...rsync because Macs are weird
+	rsync -aPr $compiled/$ngalebuild/* $compiled/latest
+	
+	uploadPackages
+}
+
+function uploadPackages() {
+	# Uploading on sourceforge.net
+	cd $compiled
+	rsync -e ssh $ngalebuild ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
+	rsync -e ssh latest ${sfnetuser}@frs.sourceforge.net://home//pfs//project//ngale//${branchname}-Nightlies -r --progress
+	rsync -e ssh $ngalebuild/addons ngaleoss@getnightingale.com://home//ngaleoss//addon-files.getnightingale.com//xpis//nightlies -r --progress
+}


### PR DESCRIPTION
Until/unless we ever end up with binary addons, we should just use the ones built on Linux...even though they should all in theory be identical, I don't trust the ones built on Mac or Windows as much not to break, especially since both Mac and Windows tend to lag behind in terms of development and in regard to their xulrunner versions.

I'd also suggest we maybe get something setup to coordinate the buildbots via a server, and build into the script the ability to determine if the machine the script is running on is supposed to build anything more than the client itself in later versions.

GeekShadow: I cleaned up the comments a bit too, but you may want to remove the space on line 1 if you merge this...and remove any double space comment situations I created.
